### PR TITLE
feat(issue-5): add screening and HR review gate

### DIFF
--- a/backend/evidence/issue5-screening-review-gate/summary.md
+++ b/backend/evidence/issue5-screening-review-gate/summary.md
@@ -1,0 +1,31 @@
+# Issue-5 Screening + HR Review Gate 证据
+
+执行时间：2026-03-30  
+范围：仅包含 #5（筛选与复核接口、状态机与人审闸门、审计与事件）
+
+## 本次实现点
+
+1. 接口：
+   - `POST /api/v1/candidate/resume/screen`
+   - `GET /api/v1/candidate/resume/screen/result/{candidateId}`
+   - `POST /api/v1/candidate/resume/screen/review`
+2. 状态机：
+   - `screen_status` 合法流转校验（`1->2/3/4`, `3->1`）
+   - `review` 前置条件校验（仅 `screen_status=2` 且筛选结果完整可复核）
+3. 人审闸门：
+   - 响应增加 `aiSuggestionOnly=true`
+   - AI 侧不直接写入 `reviewResult`，仅给建议
+4. 审计与事件：
+   - 关键动作写入审计记录（触发筛选、人工复核）
+   - MQ/Webhook 事件命名遵循映射口径（`candidate.resume.screen` -> `candidate.resume.screened`）
+
+## 自动化测试
+
+- 回归：`ContractBaselineApiTest` + `Regression30ApiTest`
+- 新增：`Issue5ScreeningReviewGateTest`
+- 覆盖点：
+  - 人审闸门字段校验
+  - 非法复核结论拦截
+  - 非法状态流转拦截
+  - 并发幂等（筛选）
+  - 审计记录落地

--- a/backend/src/main/java/com/openinterview/common/ErrorCode.java
+++ b/backend/src/main/java/com/openinterview/common/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     RESUME_SCREEN_FAILED(8002),
     AI_REVIEW_REQUIRED(8004),
     ANSWER_EVALUATE_FAILED(8005),
+    SCREEN_STATUS_ILLEGAL(8006),
     SYSTEM_ERROR(9001);
 
     private final int code;

--- a/backend/src/main/java/com/openinterview/controller/CandidateController.java
+++ b/backend/src/main/java/com/openinterview/controller/CandidateController.java
@@ -1,6 +1,7 @@
 package com.openinterview.controller;
 
 import com.openinterview.common.Result;
+import com.openinterview.service.AuditTrailService;
 import com.openinterview.service.EventMappingService;
 import com.openinterview.service.InMemoryWorkflowService;
 import com.openinterview.trace.TraceContext;
@@ -19,13 +20,16 @@ public class CandidateController {
     private final InMemoryWorkflowService workflowService;
     private final EventMappingService eventMappingService;
     private final com.openinterview.service.EventBridgeService eventBridgeService;
+    private final AuditTrailService auditTrailService;
 
     public CandidateController(InMemoryWorkflowService workflowService,
                                EventMappingService eventMappingService,
-                               com.openinterview.service.EventBridgeService eventBridgeService) {
+                               com.openinterview.service.EventBridgeService eventBridgeService,
+                               AuditTrailService auditTrailService) {
         this.workflowService = workflowService;
         this.eventMappingService = eventMappingService;
         this.eventBridgeService = eventBridgeService;
+        this.auditTrailService = auditTrailService;
     }
 
     @PostMapping("/screen")
@@ -33,16 +37,22 @@ public class CandidateController {
                                               @RequestHeader("X-Idempotency-Key") String idemKey) {
         InMemoryWorkflowService.ScreenResult result =
                 workflowService.createOrGetScreenResult(request.candidateId, request.jobCode, idemKey);
-        workflowService.markScreenSuccess(request.candidateId, request.jobCode, 82.5, 1);
+        if (InMemoryWorkflowService.SCREEN_PROCESSING == result.screenStatus) {
+            workflowService.markScreenSuccess(request.candidateId, request.jobCode, 82.5, 1);
+            result = workflowService.getScreenResult(request.candidateId, request.jobCode);
+        }
         String mqEvent = "candidate.resume.screen";
         String webhookEvent = eventMappingService.toWebhookEvent(mqEvent);
 
         Map<String, Object> data = new HashMap<>();
         data.put("taskCode", result.bizCode);
-        data.put("screenStatus", InMemoryWorkflowService.SCREEN_SUCCESS);
+        data.put("screenStatus", result.screenStatus);
+        data.put("reasonSummary", result.reasonSummary);
+        data.put("aiSuggestionOnly", true);
         data.put("mqEventCode", mqEvent);
         data.put("webhookEventCode", webhookEvent);
         eventBridgeService.publish(mqEvent, result.bizCode, data);
+        auditTrailService.record("candidate", "resume.screen", result.bizCode, "0", "触发简历筛选并进入人工复核闸门");
         return Result.success(data, TraceContext.getTraceId(), result.bizCode);
     }
 
@@ -56,6 +66,7 @@ public class CandidateController {
         data.put("screenStatus", result.screenStatus);
         data.put("matchScore", result.matchScore);
         data.put("recommendLevel", result.recommendLevel);
+        data.put("reasonSummary", result.reasonSummary);
         data.put("reviewResult", result.reviewResult);
         return Result.success(data, TraceContext.getTraceId(), result.bizCode);
     }
@@ -70,6 +81,7 @@ public class CandidateController {
         data.put("reviewResult", result.reviewResult);
         data.put("reviewComment", result.reviewComment);
         data.put("reviewTime", result.reviewTime);
+        auditTrailService.record("candidate", "resume.screen.review", result.bizCode, "0", "HR完成人工复核");
         return Result.success(data, TraceContext.getTraceId(), result.bizCode);
     }
 

--- a/backend/src/main/java/com/openinterview/controller/EvidenceController.java
+++ b/backend/src/main/java/com/openinterview/controller/EvidenceController.java
@@ -1,6 +1,7 @@
 package com.openinterview.controller;
 
 import com.openinterview.common.Result;
+import com.openinterview.service.AuditTrailService;
 import com.openinterview.service.EvidenceStore;
 import com.openinterview.trace.TraceContext;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +15,11 @@ import java.util.Map;
 @RequestMapping("/api/v1/internal/evidence")
 public class EvidenceController {
     private final EvidenceStore evidenceStore;
+    private final AuditTrailService auditTrailService;
 
-    public EvidenceController(EvidenceStore evidenceStore) {
+    public EvidenceController(EvidenceStore evidenceStore, AuditTrailService auditTrailService) {
         this.evidenceStore = evidenceStore;
+        this.auditTrailService = auditTrailService;
     }
 
     @GetMapping("/events")
@@ -24,6 +27,7 @@ public class EvidenceController {
         Map<String, Object> data = new HashMap<>();
         data.put("mqEvents", evidenceStore.getMqEvents());
         data.put("webhookEvents", evidenceStore.getWebhookEvents());
+        data.put("auditLogs", auditTrailService.list());
         return Result.success(data, TraceContext.getTraceId(), "EVIDENCE_EVENTS");
     }
 }

--- a/backend/src/main/java/com/openinterview/service/AuditTrailService.java
+++ b/backend/src/main/java/com/openinterview/service/AuditTrailService.java
@@ -1,0 +1,41 @@
+package com.openinterview.service;
+
+import com.openinterview.trace.TraceContext;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class AuditTrailService {
+    private final List<AuditRecord> records = Collections.synchronizedList(new ArrayList<>());
+
+    public void record(String module, String action, String bizCode, String errorCode, String detail) {
+        AuditRecord record = new AuditRecord();
+        record.module = module;
+        record.action = action;
+        record.traceId = TraceContext.getTraceId();
+        record.bizCode = bizCode;
+        record.errorCode = errorCode;
+        record.detail = detail;
+        record.occurTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        records.add(record);
+    }
+
+    public List<AuditRecord> list() {
+        return new ArrayList<>(records);
+    }
+
+    public static class AuditRecord {
+        public String module;
+        public String action;
+        public String traceId;
+        public String bizCode;
+        public String errorCode;
+        public String detail;
+        public String occurTime;
+    }
+}

--- a/backend/src/main/java/com/openinterview/service/EventBridgeService.java
+++ b/backend/src/main/java/com/openinterview/service/EventBridgeService.java
@@ -42,6 +42,7 @@ public class EventBridgeService {
 
         String webhookEventCode = eventMappingService.toWebhookEvent(mqEventCode);
         EventMessage webhookMsg = EventMessage.of(webhookEventCode, traceId, bizCode, payload);
+        evidenceStore.addWebhook(webhookMsg);
 
         if (properties.isWebhookEnabled()) {
             restClient.post()

--- a/backend/src/main/java/com/openinterview/service/InMemoryWorkflowService.java
+++ b/backend/src/main/java/com/openinterview/service/InMemoryWorkflowService.java
@@ -22,6 +22,9 @@ public class InMemoryWorkflowService {
     public static final int REVIEW_PENDING = 1;
     public static final int REVIEW_APPROVED = 2;
     public static final int REVIEW_REJECTED = 3;
+    public static final int SCREEN_REVIEW_PASS = 1;
+    public static final int SCREEN_REVIEW_PENDING = 2;
+    public static final int SCREEN_REVIEW_REJECT = 3;
 
     public static final int EXPORT_SCREENING_EXCEL = 0;
     public static final int EXPORT_INTERVIEW_EXCEL = 1;
@@ -37,14 +40,8 @@ public class InMemoryWorkflowService {
     private final Map<String, ExportTask> exportTaskStore = new ConcurrentHashMap<>();
 
     public <T> T idempotent(String key, Supplier<T> supplier) {
-        Object old = idemCache.get(key);
-        if (old != null) {
-            @SuppressWarnings("unchecked")
-            T oldValue = (T) old;
-            return oldValue;
-        }
-        T value = supplier.get();
-        idemCache.put(key, value);
+        @SuppressWarnings("unchecked")
+        T value = (T) idemCache.computeIfAbsent(key, k -> supplier.get());
         return value;
     }
 
@@ -71,6 +68,12 @@ public class InMemoryWorkflowService {
             ScreenResult result = getScreenResult(candidateId, jobCode);
             if (result.screenStatus != SCREEN_SUCCESS) {
                 throw new ApiException(ErrorCode.AI_REVIEW_REQUIRED, result.bizCode, "筛选未成功，禁止复核");
+            }
+            if (result.matchScore == null || result.recommendLevel == null) {
+                throw new ApiException(ErrorCode.AI_REVIEW_REQUIRED, result.bizCode, "筛选结果不完整，禁止复核");
+            }
+            if (!isValidScreenReviewResult(reviewResult)) {
+                throw new ApiException(ErrorCode.PARAM_INVALID, result.bizCode, "复核结论非法，仅允许 1/2/3");
             }
             result.reviewResult = reviewResult;
             result.reviewComment = reviewComment;
@@ -152,9 +155,38 @@ public class InMemoryWorkflowService {
 
     public void markScreenSuccess(Long candidateId, String jobCode, double matchScore, int recommendLevel) {
         ScreenResult result = getScreenResult(candidateId, jobCode);
-        result.screenStatus = SCREEN_SUCCESS;
+        transitScreenStatus(result, SCREEN_SUCCESS);
         result.matchScore = BigDecimal.valueOf(matchScore);
         result.recommendLevel = recommendLevel;
+        result.reasonSummary = "AI仅输出建议，需HR复核后生效";
+    }
+
+    public void markScreenFailed(Long candidateId, String jobCode, String failReason) {
+        ScreenResult result = getScreenResult(candidateId, jobCode);
+        transitScreenStatus(result, SCREEN_FAILED);
+        result.failReason = failReason;
+    }
+
+    public void retryScreen(Long candidateId, String jobCode) {
+        ScreenResult result = getScreenResult(candidateId, jobCode);
+        transitScreenStatus(result, SCREEN_PROCESSING);
+    }
+
+    private void transitScreenStatus(ScreenResult result, int targetStatus) {
+        int current = result.screenStatus;
+        boolean allowed = (current == SCREEN_PROCESSING && (targetStatus == SCREEN_SUCCESS || targetStatus == SCREEN_FAILED || targetStatus == SCREEN_CANCELED))
+                || (current == SCREEN_FAILED && targetStatus == SCREEN_PROCESSING);
+        if (!allowed) {
+            throw new ApiException(ErrorCode.SCREEN_STATUS_ILLEGAL, result.bizCode, "screen_status 非法流转: " + current + "->" + targetStatus);
+        }
+        result.screenStatus = targetStatus;
+    }
+
+    private boolean isValidScreenReviewResult(Integer reviewResult) {
+        return reviewResult != null
+                && (reviewResult == SCREEN_REVIEW_PASS
+                || reviewResult == SCREEN_REVIEW_PENDING
+                || reviewResult == SCREEN_REVIEW_REJECT);
     }
 
     private String nowCode() {
@@ -167,9 +199,11 @@ public class InMemoryWorkflowService {
         public Integer screenStatus;
         public BigDecimal matchScore;
         public Integer recommendLevel;
+        public String reasonSummary;
         public Integer reviewResult;
         public String reviewComment;
         public String reviewTime;
+        public String failReason;
         public String bizCode;
 
         public ScreenResult(Long candidateId, String jobCode, String bizCode) {

--- a/backend/src/test/java/com/openinterview/Issue5ScreeningReviewGateTest.java
+++ b/backend/src/test/java/com/openinterview/Issue5ScreeningReviewGateTest.java
@@ -1,0 +1,141 @@
+package com.openinterview;
+
+import com.openinterview.common.ApiException;
+import com.openinterview.common.ErrorCode;
+import com.openinterview.service.InMemoryWorkflowService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class Issue5ScreeningReviewGateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private InMemoryWorkflowService workflowService;
+
+    @Test
+    void screenResultShouldContainHumanReviewGateFlag() throws Exception {
+        mockMvc.perform(post("/api/v1/candidate/resume/screen")
+                        .header("X-Idempotency-Key", "issue5-case-01")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"candidateId\":30001,\"jobCode\":\"JAVA_ADV_01\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.aiSuggestionOnly").value(true))
+                .andExpect(jsonPath("$.data.reasonSummary").exists());
+
+        mockMvc.perform(get("/api/v1/candidate/resume/screen/result/30001")
+                        .param("jobCode", "JAVA_ADV_01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviewResult").isEmpty());
+    }
+
+    @Test
+    void reviewWithInvalidReviewResultShouldFail() throws Exception {
+        mockMvc.perform(post("/api/v1/candidate/resume/screen")
+                        .header("X-Idempotency-Key", "issue5-case-02-a")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"candidateId\":30002,\"jobCode\":\"JAVA_ADV_01\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/candidate/resume/screen/review")
+                        .header("X-Idempotency-Key", "issue5-case-02-b")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"candidateId\":30002,\"jobCode\":\"JAVA_ADV_01\",\"reviewResult\":4,\"reviewComment\":\"invalid\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(1001));
+    }
+
+    @Test
+    void screenStatusIllegalTransitionShouldFail() {
+        workflowService.createOrGetScreenResult(30003L, "JAVA_ADV_01", "issue5-case-03-a");
+        workflowService.markScreenSuccess(30003L, "JAVA_ADV_01", 80.0, 2);
+        ApiException ex = Assertions.assertThrows(
+                ApiException.class,
+                () -> workflowService.markScreenFailed(30003L, "JAVA_ADV_01", "should-fail")
+        );
+        Assertions.assertEquals(ErrorCode.SCREEN_STATUS_ILLEGAL, ex.getErrorCode());
+    }
+
+    @Test
+    void concurrentScreenWithSameIdempotencyKeyShouldReturnSameTaskCode() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            List<Callable<String>> calls = new ArrayList<>();
+            for (int i = 0; i < 4; i++) {
+                calls.add(() -> {
+                    MvcResult result = mockMvc.perform(post("/api/v1/candidate/resume/screen")
+                                    .header("X-Idempotency-Key", "issue5-case-04")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"candidateId\":30004,\"jobCode\":\"JAVA_ADV_01\"}"))
+                            .andExpect(status().isOk())
+                            .andReturn();
+                    return extract(result.getResponse().getContentAsString(), "\"taskCode\":\"", "\"");
+                });
+            }
+            List<Future<String>> futures = executor.invokeAll(calls);
+            String expected = futures.get(0).get();
+            for (Future<String> future : futures) {
+                Assertions.assertEquals(expected, future.get());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void keyActionsShouldBeRecordedInAuditTrail() throws Exception {
+        mockMvc.perform(post("/api/v1/candidate/resume/screen")
+                        .header("X-Idempotency-Key", "issue5-case-06-a")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"candidateId\":30006,\"jobCode\":\"JAVA_ADV_01\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/candidate/resume/screen/review")
+                        .header("X-Idempotency-Key", "issue5-case-06-b")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"candidateId\":30006,\"jobCode\":\"JAVA_ADV_01\",\"reviewResult\":1,\"reviewComment\":\"pass\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/internal/evidence/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.auditLogs").isArray())
+                .andExpect(jsonPath("$.data.auditLogs[0].module").value("candidate"))
+                .andExpect(jsonPath("$.data.auditLogs[0].traceId").exists())
+                .andExpect(jsonPath("$.data.auditLogs[0].bizCode").exists())
+                .andExpect(jsonPath("$.data.auditLogs[0].errorCode").exists());
+    }
+
+    private String extract(String body, String left, String right) {
+        int start = body.indexOf(left);
+        if (start < 0) {
+            return "";
+        }
+        int from = start + left.length();
+        int end = body.indexOf(right, from);
+        if (end < 0) {
+            end = body.length();
+        }
+        return body.substring(from, end);
+    }
+}


### PR DESCRIPTION
## Summary
- add `candidate/resume/screen`, `candidate/resume/screen/result/{candidateId}`, `candidate/resume/screen/review` gate enforcement with strict `screen_status` transitions
- enforce review preconditions and explicit `aiSuggestionOnly=true` guard so AI cannot directly eliminate candidates
- record screening and review key actions into audit evidence and align MQ/Webhook mapping behavior

## Test plan
- [x] `mvn test -Dtest=ContractBaselineApiTest,Regression30ApiTest,Issue5ScreeningReviewGateTest`
- [x] verify idempotency repeat and concurrent same-key behavior in `Issue5ScreeningReviewGateTest`
- [x] verify illegal transition returns `8006` and invalid review result returns `1001`

Made with [Cursor](https://cursor.com)