### PR TITLE
[AFK] Slice-08 MQ to Webhook Event Bridge

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/openinterview/controller/CandidateController.java
+++ b/backend/src/main/java/com/openinterview/controller/CandidateController.java
@@ -50,6 +50,10 @@ public class CandidateController {
         Map<String, Object> data = new HashMap<>();
         data.put("candidateId", result.candidateId);
         data.put("resumeUrl", result.resumeUrl);
+        String mqEvent = "candidate.resume.upload";
+        data.put("mqEventCode", mqEvent);
+        data.put("webhookEventCode", eventMappingService.toWebhookEvent(mqEvent));
+        eventBridgeService.publish(mqEvent, result.bizCode, data);
         auditTrailService.record("candidate", "resume.upload", result.bizCode, "0", "简历上传至对象存储(mock)");
         return Result.success(data, TraceContext.getTraceId(), result.bizCode);
     }
@@ -70,6 +74,7 @@ public class CandidateController {
         data.put("parseStatus", task.parseStatus);
         data.put("mqEventCode", mqEvent);
         data.put("webhookEventCode", webhookEvent);
+        eventBridgeService.publish(mqEvent, task.bizCode, data);
         auditTrailService.record("candidate", "resume.parse", task.bizCode, "0", "触发异步解析任务");
         return Result.success(data, traceId, task.bizCode);
     }
@@ -138,6 +143,10 @@ public class CandidateController {
         data.put("reviewResult", result.reviewResult);
         data.put("reviewComment", result.reviewComment);
         data.put("reviewTime", result.reviewTime);
+        String mqEvent = "candidate.resume.screen.review";
+        data.put("mqEventCode", mqEvent);
+        data.put("webhookEventCode", eventMappingService.toWebhookEvent(mqEvent));
+        eventBridgeService.publish(mqEvent, result.bizCode, data);
         auditTrailService.record("candidate", "resume.screen.review", result.bizCode, "0", "HR完成人工复核");
         return Result.success(data, TraceContext.getTraceId(), result.bizCode);
     }

--- a/backend/src/main/java/com/openinterview/controller/EvidenceController.java
+++ b/backend/src/main/java/com/openinterview/controller/EvidenceController.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/v1/internal/evidence")
+@RequestMapping({"/api/v1/internal/evidence", "/api/v1/evidence"})
 public class EvidenceController {
     private final EvidenceStore evidenceStore;
     private final AuditTrailService auditTrailService;
@@ -35,6 +35,7 @@ public class EvidenceController {
         data.put("auditLogs", auditTrailService.list());
         data.put("parseFailureAudits", workflowService.getParseFailureAudits());
         data.put("exportAudits", evidenceStore.getExportAudits());
+        data.put("webhookDeliveryFailures", evidenceStore.getWebhookDeliveryFailures());
         return Result.success(data, TraceContext.getTraceId(), "EVIDENCE_EVENTS");
     }
 }

--- a/backend/src/main/java/com/openinterview/controller/ExportController.java
+++ b/backend/src/main/java/com/openinterview/controller/ExportController.java
@@ -141,8 +141,8 @@ public class ExportController {
 
     private Result<Map<String, Object>> createExport(int exportType, String content, String jobCode, String idemKey) {
         InMemoryWorkflowService.ExportTask task = workflowService.createExportTask(exportType, content, jobCode, idemKey);
-        String mqEvent = "export.generate";
-        String webhookEvent = eventMappingService.toWebhookEvent(mqEvent);
+        String mqCreate = "export.task.create";
+        String webhookCreate = eventMappingService.toWebhookEvent(mqCreate);
         Map<String, Object> data = new HashMap<>();
         data.put("taskId", task.taskId);
         data.put("taskCode", task.taskCode);
@@ -156,9 +156,14 @@ public class ExportController {
         data.put("fileSize", task.fileSize);
         data.put("failReason", task.failReason);
         data.put("retryCount", task.retryCount);
-        data.put("mqEventCode", mqEvent);
-        data.put("webhookEventCode", webhookEvent);
-        eventBridgeService.publish(mqEvent, task.bizCode, data);
+        data.put("mqEventCode", mqCreate);
+        data.put("webhookEventCode", webhookCreate);
+        eventBridgeService.publish(mqCreate, task.bizCode, data);
+        if (task.taskStatus == InMemoryWorkflowService.TASK_SUCCESS) {
+            eventBridgeService.publish("export.task.complete", task.bizCode, data);
+        } else if (task.taskStatus == InMemoryWorkflowService.TASK_FAILED) {
+            eventBridgeService.publish("export.task.failed", task.bizCode, data);
+        }
         evidenceStore.addExportAudit(auditPayload("EXPORT_CREATE", task));
         auditTrailService.record("export", "export.create", task.bizCode,
                 task.taskStatus == InMemoryWorkflowService.TASK_FAILED ? task.lastErrorCode : "0",

--- a/backend/src/main/java/com/openinterview/controller/InterviewAssistantController.java
+++ b/backend/src/main/java/com/openinterview/controller/InterviewAssistantController.java
@@ -65,6 +65,10 @@ public class InterviewAssistantController {
         data.put("reviewStatus", record.reviewStatus);
         data.put("reviewComment", record.reviewComment);
         data.put("reviewTime", record.reviewTime);
+        String mqEvent = "interview.question.review";
+        data.put("mqEventCode", mqEvent);
+        data.put("webhookEventCode", eventMappingService.toWebhookEvent(mqEvent));
+        eventBridgeService.publish(mqEvent, record.bizCode, data);
         return Result.success(data, TraceContext.getTraceId(), record.bizCode);
     }
 
@@ -74,7 +78,7 @@ public class InterviewAssistantController {
         InMemoryWorkflowService.AnswerEvaluateResult result = workflowService.evaluateAnswer(
                 request.interviewId, request.questionId, request.answerText, idemKey
         );
-        String mqEvent = "interview.answer.evaluate";
+        String mqEvent = "interview.assistant.answer.evaluate";
         String webhookEvent = eventMappingService.toWebhookEvent(mqEvent);
         Map<String, Object> data = new HashMap<>();
         data.put("accuracyScore", result.accuracyScore);

--- a/backend/src/main/java/com/openinterview/controller/WebhookMockController.java
+++ b/backend/src/main/java/com/openinterview/controller/WebhookMockController.java
@@ -1,25 +1,26 @@
 package com.openinterview.controller;
 
 import com.openinterview.common.Result;
-import com.openinterview.service.EvidenceStore;
-import com.openinterview.service.EventMessage;
 import com.openinterview.trace.TraceContext;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
 @RestController
-@RequestMapping("/webhook/mock")
+@RequestMapping({"/webhook/mock", "/api/v1/webhook/mock"})
 public class WebhookMockController {
-    private final EvidenceStore evidenceStore;
-
-    public WebhookMockController(EvidenceStore evidenceStore) {
-        this.evidenceStore = evidenceStore;
-    }
 
     @PostMapping("/receive")
-    public Result<Map<String, Object>> receive(@RequestBody EventMessage eventMessage) {
-        evidenceStore.addWebhook(eventMessage);
+    public Result<Map<String, Object>> receive(@RequestBody com.openinterview.service.EventMessage eventMessage) {
         return Result.success(Map.of("accepted", true), TraceContext.getTraceId(), eventMessage.bizCode);
+    }
+
+    /** 模拟下游返回 500，用于验证 Webhook 重试与失败证据 */
+    @PostMapping("/fail")
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result<Map<String, Object>> fail(@RequestBody(required = false) com.openinterview.service.EventMessage eventMessage) {
+        return Result.success(Map.of("accepted", false, "reason", "mock failure"), TraceContext.getTraceId(),
+                eventMessage != null ? eventMessage.bizCode : "MOCK_FAIL");
     }
 }

--- a/backend/src/main/java/com/openinterview/service/EventBridgeService.java
+++ b/backend/src/main/java/com/openinterview/service/EventBridgeService.java
@@ -3,14 +3,19 @@ package com.openinterview.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openinterview.config.EventBridgeProperties;
 import com.openinterview.trace.TraceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 import java.util.Map;
 
 @Service
 public class EventBridgeService {
+    private static final Logger log = LoggerFactory.getLogger(EventBridgeService.class);
+
     private final EventMappingService eventMappingService;
     private final EventBridgeProperties properties;
     private final RabbitTemplate rabbitTemplate;
@@ -48,13 +53,37 @@ public class EventBridgeService {
         evidenceStore.addWebhook(webhookMsg);
 
         if (properties.isWebhookEnabled()) {
+            boolean ok = postWebhook(webhookMsg);
+            if (!ok) {
+                webhookMsg.retryCount = 1;
+                log.warn("webhook first attempt failed, retrying once traceId={} bizCode={} mq={} webhook={}",
+                        traceId, bizCode, mqEventCode, webhookEventCode);
+                ok = postWebhook(webhookMsg);
+                if (!ok) {
+                    String err = "WEBHOOK_DELIVERY_FAILED";
+                    String reason = "HTTP callback failed after retries";
+                    log.error("webhook delivery failed after retry traceId={} bizCode={} mq={} webhook={}",
+                            traceId, bizCode, mqEventCode, webhookEventCode);
+                    evidenceStore.addWebhookDeliveryFailure(traceId, bizCode, err, reason, mqEventCode, webhookEventCode);
+                }
+            }
+        }
+        return webhookMsg;
+    }
+
+    private boolean postWebhook(EventMessage webhookMsg) {
+        try {
             restClient.post()
                     .uri(properties.getWebhookUrl())
                     .body(webhookMsg)
                     .retrieve()
                     .toBodilessEntity();
+            return true;
+        } catch (RestClientException ex) {
+            log.warn("webhook post failed traceId={} bizCode={} err={}",
+                    webhookMsg.traceId, webhookMsg.bizCode, ex.getMessage());
+            return false;
         }
-        return webhookMsg;
     }
 
     private String toJson(Object obj) {

--- a/backend/src/main/java/com/openinterview/service/EventMappingService.java
+++ b/backend/src/main/java/com/openinterview/service/EventMappingService.java
@@ -2,19 +2,37 @@ package com.openinterview.service;
 
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * MQ 内部命令语义 → Webhook 外部事实语义（与契约基线 / 详细设计 6.5 及 Slice-08 验收表一致）。
+ */
 @Service
 public class EventMappingService {
-    private static final Map<String, String> MAPPING = Map.of(
-            "candidate.resume.parse", "candidate.resume.parsed",
-            "candidate.resume.screen", "candidate.resume.screened",
-            "interview.assistant.question.generate", "interview.question.generated",
-            "interview.answer.evaluate", "interview.answer.evaluated",
-            "export.generate", "export.generated"
-    );
+    private static final Map<String, String> MAPPING = new HashMap<>();
 
+    static {
+        MAPPING.put("candidate.resume.upload", "CANDIDATE_RESUME_UPLOADED");
+        MAPPING.put("candidate.resume.parse", "CANDIDATE_RESUME_PARSED");
+        MAPPING.put("candidate.resume.screen", "CANDIDATE_RESUME_SCREENED");
+        MAPPING.put("candidate.resume.screen.review", "CANDIDATE_SCREEN_REVIEWED");
+        MAPPING.put("interview.assistant.question.generate", "INTERVIEW_QUESTION_GENERATED");
+        MAPPING.put("interview.question.review", "INTERVIEW_QUESTION_REVIEWED");
+        MAPPING.put("interview.assistant.answer.evaluate", "INTERVIEW_ANSWER_EVALUATED");
+        MAPPING.put("export.task.create", "EXPORT_TASK_CREATED");
+        MAPPING.put("export.task.complete", "EXPORT_TASK_COMPLETED");
+        MAPPING.put("export.task.failed", "EXPORT_TASK_FAILED");
+    }
+
+    /**
+     * 未映射的 MQ 事件：降级为原样透传（便于观测与兼容旧路由键）。
+     */
     public String toWebhookEvent(String mqEvent) {
         return MAPPING.getOrDefault(mqEvent, mqEvent);
+    }
+
+    public boolean isMapped(String mqEvent) {
+        return MAPPING.containsKey(mqEvent);
     }
 }

--- a/backend/src/main/java/com/openinterview/service/EvidenceStore.java
+++ b/backend/src/main/java/com/openinterview/service/EvidenceStore.java
@@ -12,6 +12,7 @@ public class EvidenceStore {
     private final List<EventMessage> mqEvents = Collections.synchronizedList(new ArrayList<>());
     private final List<EventMessage> webhookEvents = Collections.synchronizedList(new ArrayList<>());
     private final List<Map<String, Object>> exportAudits = Collections.synchronizedList(new ArrayList<>());
+    private final List<Map<String, Object>> webhookDeliveryFailures = Collections.synchronizedList(new ArrayList<>());
 
     public void addMq(EventMessage event) {
         mqEvents.add(event);
@@ -35,5 +36,29 @@ public class EvidenceStore {
 
     public List<Map<String, Object>> getExportAudits() {
         return new ArrayList<>(exportAudits);
+    }
+
+    /**
+     * Webhook 回调在重试后仍失败时记录，便于按 traceId / bizCode 追溯。
+     */
+    public void addWebhookDeliveryFailure(String traceId,
+                                          String bizCode,
+                                          String errorCode,
+                                          String failReason,
+                                          String mqEventCode,
+                                          String webhookEventCode) {
+        Map<String, Object> row = new java.util.LinkedHashMap<>();
+        row.put("traceId", traceId);
+        row.put("bizCode", bizCode);
+        row.put("errorCode", errorCode);
+        row.put("failReason", failReason);
+        row.put("mqEventCode", mqEventCode);
+        row.put("webhookEventCode", webhookEventCode);
+        row.put("occurTime", java.time.LocalDateTime.now().toString());
+        webhookDeliveryFailures.add(row);
+    }
+
+    public List<Map<String, Object>> getWebhookDeliveryFailures() {
+        return new ArrayList<>(webhookDeliveryFailures);
     }
 }

--- a/backend/src/test/java/com/openinterview/ContractBaselineApiTest.java
+++ b/backend/src/test/java/com/openinterview/ContractBaselineApiTest.java
@@ -46,7 +46,7 @@ class ContractBaselineApiTest {
                 .andExpect(header().string("X-Trace-Id", "trace_case_01"))
                 .andExpect(jsonPath("$.data.screenStatus").value(2))
                 .andExpect(jsonPath("$.data.mqEventCode").value("candidate.resume.screen"))
-                .andExpect(jsonPath("$.data.webhookEventCode").value("candidate.resume.screened"))
+                .andExpect(jsonPath("$.data.webhookEventCode").value("CANDIDATE_RESUME_SCREENED"))
                 .andExpect(jsonPath("$.traceId").value("trace_case_01"));
 
         mockMvc.perform(get("/api/v1/candidate/resume/screen/result/10001")

--- a/backend/src/test/java/com/openinterview/Issue10BridgeToggleTest.java
+++ b/backend/src/test/java/com/openinterview/Issue10BridgeToggleTest.java
@@ -1,0 +1,38 @@
+package com.openinterview;
+
+import com.openinterview.service.EventBridgeService;
+import com.openinterview.service.EventMessage;
+import com.openinterview.service.EvidenceStore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+/**
+ * MQ / Webhook 开关独立：关闭时不发 HTTP，仍写入证据中的 MQ 与「拟投递」Webhook 载荷。
+ */
+@SpringBootTest(properties = {
+        "event.bridge.webhook-enabled=false",
+        "event.bridge.mq-enabled=false"
+})
+class Issue10BridgeToggleTest {
+
+    @Autowired
+    private EventBridgeService eventBridgeService;
+
+    @Autowired
+    private EvidenceStore evidenceStore;
+
+    @Test
+    void mqAndWebhookDisabledStillRecordsPlannedEventsInEvidence() {
+        int mq0 = evidenceStore.getMqEvents().size();
+        int wh0 = evidenceStore.getWebhookEvents().size();
+        eventBridgeService.publish("candidate.resume.screen", "BIZ-TOGGLE", Map.of());
+        Assertions.assertEquals(mq0 + 1, evidenceStore.getMqEvents().size());
+        Assertions.assertEquals(wh0 + 1, evidenceStore.getWebhookEvents().size());
+        EventMessage lastWh = evidenceStore.getWebhookEvents().get(evidenceStore.getWebhookEvents().size() - 1);
+        Assertions.assertEquals("CANDIDATE_RESUME_SCREENED", lastWh.eventCode);
+    }
+}

--- a/backend/src/test/java/com/openinterview/Issue10MqWebhookBridgeTest.java
+++ b/backend/src/test/java/com/openinterview/Issue10MqWebhookBridgeTest.java
@@ -1,0 +1,142 @@
+package com.openinterview;
+
+import com.openinterview.service.EventBridgeService;
+import com.openinterview.service.EventMappingService;
+import com.openinterview.service.EventMessage;
+import com.openinterview.service.EvidenceStore;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice-08：MQ→Webhook 映射、证据链、Webhook 重试与失败追溯。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class Issue10MqWebhookBridgeTest {
+
+    static final MockWebServer MOCK_WEB_SERVER;
+
+    static {
+        MOCK_WEB_SERVER = new MockWebServer();
+        try {
+            MOCK_WEB_SERVER.start();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DynamicPropertySource
+    static void bridgeProps(DynamicPropertyRegistry registry) {
+        registry.add("event.bridge.webhook-enabled", () -> "true");
+        registry.add("event.bridge.mq-enabled", () -> "false");
+        registry.add("event.bridge.webhook-url", () -> MOCK_WEB_SERVER.url("/receive").toString());
+    }
+
+    @AfterAll
+    static void shutdownMock() throws Exception {
+        MOCK_WEB_SERVER.shutdown();
+    }
+
+    @Autowired
+    private EventMappingService eventMappingService;
+
+    @Autowired
+    private EventBridgeService eventBridgeService;
+
+    @Autowired
+    private EvidenceStore evidenceStore;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void a_allTenMappingsMatchBaseline() {
+        Assertions.assertEquals("CANDIDATE_RESUME_UPLOADED", eventMappingService.toWebhookEvent("candidate.resume.upload"));
+        Assertions.assertEquals("CANDIDATE_RESUME_PARSED", eventMappingService.toWebhookEvent("candidate.resume.parse"));
+        Assertions.assertEquals("CANDIDATE_RESUME_SCREENED", eventMappingService.toWebhookEvent("candidate.resume.screen"));
+        Assertions.assertEquals("CANDIDATE_SCREEN_REVIEWED", eventMappingService.toWebhookEvent("candidate.resume.screen.review"));
+        Assertions.assertEquals("INTERVIEW_QUESTION_GENERATED", eventMappingService.toWebhookEvent("interview.assistant.question.generate"));
+        Assertions.assertEquals("INTERVIEW_QUESTION_REVIEWED", eventMappingService.toWebhookEvent("interview.question.review"));
+        Assertions.assertEquals("INTERVIEW_ANSWER_EVALUATED", eventMappingService.toWebhookEvent("interview.assistant.answer.evaluate"));
+        Assertions.assertEquals("EXPORT_TASK_CREATED", eventMappingService.toWebhookEvent("export.task.create"));
+        Assertions.assertEquals("EXPORT_TASK_COMPLETED", eventMappingService.toWebhookEvent("export.task.complete"));
+        Assertions.assertEquals("EXPORT_TASK_FAILED", eventMappingService.toWebhookEvent("export.task.failed"));
+    }
+
+    @Test
+    void b_publishIncreasesMqAndWebhookEvidence() {
+        int mqBefore = evidenceStore.getMqEvents().size();
+        int whBefore = evidenceStore.getWebhookEvents().size();
+        MOCK_WEB_SERVER.enqueue(new MockResponse().setResponseCode(200));
+        eventBridgeService.publish("candidate.resume.upload", "BIZ-I10-B", Map.of("k", "v"));
+        Assertions.assertEquals(mqBefore + 1, evidenceStore.getMqEvents().size());
+        Assertions.assertEquals(whBefore + 1, evidenceStore.getWebhookEvents().size());
+    }
+
+    @Test
+    void c_webhookCallbackSuccess() throws Exception {
+        long reqBefore = MOCK_WEB_SERVER.getRequestCount();
+        MOCK_WEB_SERVER.enqueue(new MockResponse().setResponseCode(200));
+        eventBridgeService.publish("export.task.create", "BIZ-I10-C", Map.of("taskId", 1L));
+        Assertions.assertEquals(reqBefore + 1, MOCK_WEB_SERVER.getRequestCount());
+    }
+
+    @Test
+    void d_webhookFailureThenRetryThenFailureEvidence() {
+        int failBefore = evidenceStore.getWebhookDeliveryFailures().size();
+        MOCK_WEB_SERVER.enqueue(new MockResponse().setResponseCode(500));
+        MOCK_WEB_SERVER.enqueue(new MockResponse().setResponseCode(500));
+        eventBridgeService.publish("candidate.resume.parse", "BIZ-I10-D", Map.of(), "trace-i10-d");
+        Assertions.assertEquals(failBefore + 1, evidenceStore.getWebhookDeliveryFailures().size());
+        Map<String, Object> last = evidenceStore.getWebhookDeliveryFailures().get(evidenceStore.getWebhookDeliveryFailures().size() - 1);
+        Assertions.assertEquals("BIZ-I10-D", last.get("bizCode"));
+        Assertions.assertEquals("candidate.resume.parse", last.get("mqEventCode"));
+        Assertions.assertEquals("CANDIDATE_RESUME_PARSED", last.get("webhookEventCode"));
+        Assertions.assertEquals("trace-i10-d", last.get("traceId"));
+    }
+
+    @Test
+    void f_unmappedMqEventPassesThroughAsWebhookName() {
+        Assertions.assertEquals("custom.unknown.event", eventMappingService.toWebhookEvent("custom.unknown.event"));
+        Assertions.assertFalse(eventMappingService.isMapped("custom.unknown.event"));
+    }
+
+    @Test
+    void g_traceIdAndBizCodePropagatedInEventMessage() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("x", 1);
+        MOCK_WEB_SERVER.enqueue(new MockResponse().setResponseCode(200));
+        eventBridgeService.publish("interview.assistant.answer.evaluate", "BIZ-TRACE", payload, "trace-issue10-g");
+        EventMessage mq = evidenceStore.getMqEvents().get(evidenceStore.getMqEvents().size() - 1);
+        EventMessage wh = evidenceStore.getWebhookEvents().get(evidenceStore.getWebhookEvents().size() - 1);
+        Assertions.assertEquals("trace-issue10-g", mq.traceId);
+        Assertions.assertEquals("BIZ-TRACE", mq.bizCode);
+        Assertions.assertEquals("trace-issue10-g", wh.traceId);
+        Assertions.assertEquals("BIZ-TRACE", wh.bizCode);
+    }
+
+    @Test
+    void h_evidenceEndpointExposesMqAndWebhookArrays() throws Exception {
+        mockMvc.perform(get("/api/v1/evidence/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.mqEvents").isArray())
+                .andExpect(jsonPath("$.data.webhookEvents").isArray())
+                .andExpect(jsonPath("$.data.webhookDeliveryFailures").isArray());
+    }
+}

--- a/backend/src/test/java/com/openinterview/Issue8AnswerEvaluateTest.java
+++ b/backend/src/test/java/com/openinterview/Issue8AnswerEvaluateTest.java
@@ -108,7 +108,7 @@ class Issue8AnswerEvaluateTest {
                 .andExpect(jsonPath("$.data.mqEvents").isArray())
                 .andReturn();
         String evidence = ev.getResponse().getContentAsString();
-        Assertions.assertTrue(evidence.contains("\"eventCode\":\"interview.answer.evaluate\""));
+        Assertions.assertTrue(evidence.contains("\"eventCode\":\"interview.assistant.answer.evaluate\""));
         Assertions.assertTrue(evidence.contains("\"bizCode\":\"" + bizCode + "\""));
         Assertions.assertTrue(evidence.contains("trace-issue8-f"));
     }

--- a/backend/src/test/java/com/openinterview/Regression30ApiTest.java
+++ b/backend/src/test/java/com/openinterview/Regression30ApiTest.java
@@ -153,7 +153,7 @@ class Regression30ApiTest {
                         .content("{\"candidateId\":10010,\"jobCode\":\"JAVA_ADV_01\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.mqEventCode").value("candidate.resume.screen"))
-                .andExpect(jsonPath("$.data.webhookEventCode").value("candidate.resume.screened"));
+                .andExpect(jsonPath("$.data.webhookEventCode").value("CANDIDATE_RESUME_SCREENED"));
     }
 
     @Test
@@ -248,7 +248,7 @@ class Regression30ApiTest {
                         .content("{\"interviewId\":50017,\"questionId\":70017,\"answerText\":\"answer\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.accuracyScore").exists())
-                .andExpect(jsonPath("$.data.webhookEventCode").value("interview.answer.evaluated"));
+                .andExpect(jsonPath("$.data.webhookEventCode").value("INTERVIEW_ANSWER_EVALUATED"));
     }
 
     @Test


### PR DESCRIPTION
Closes #10

## Summary
- 事件映射覆盖全部 10 个关键事件
- Webhook 回调失败重试 + 失败证据记录
- 补齐 Controller 缺失的事件发布
- 新增 Issue10MqWebhookBridgeTest

## Test
mvn test: 全绿

Made with [Cursor](https://cursor.com)