### PR TITLE
feat: gate merges on local Cursor subagent completion

### DIFF
--- a/.github/rulesets/default-main.json
+++ b/.github/rulesets/default-main.json
@@ -39,6 +39,9 @@
         "required_status_checks": [
           {
             "context": "backend-mvn-test"
+          },
+          {
+            "context": "local-subagent-gate"
           }
         ]
       }

--- a/.github/workflows/agent-module.yml
+++ b/.github/workflows/agent-module.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Create branch and PR if not exists (one issue one PR)
         if: steps.gate.outputs.run == 'true'
+        id: create_pr
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -112,10 +113,19 @@ Auto-generated PR for issue #${ISSUE} by agent-module workflow.
 
 DoD (skeleton):
 - [ ] backend-mvn-test green
+- [ ] local-subagent-gate green (add PR label: subagent:done)
 - [ ] Update code for module: ${MOD}
 - [ ] Fill evidence in ${evidence_dir}/summary.md
 EOF
 )" >/dev/null
+
+          echo "evidence_dir=${evidence_dir}" >> "$GITHUB_OUTPUT"
+
+          pr_number="$(gh api "repos/${REPO}/pulls?state=open&head=${owner}:${branch}" --jq '.[0].number')"
+          if [ -n "${pr_number}" ] && [ "${pr_number}" != "null" ]; then
+            gh api -X POST "repos/${REPO}/issues/${pr_number}/labels" -f labels[]="subagent:pending" >/dev/null || true
+            echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post placeholder delivery note
         if: steps.gate.outputs.run == 'true'
@@ -132,12 +142,20 @@ EOF
             exit 0
           fi
 
+          evidence_dir="${{ steps.create_pr.outputs.evidence_dir }}"
           gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -f body="$(cat <<EOF
 ${marker}
 Agent(${MOD}): 已接单（status:in_progress）。
 
-本仓库当前为 Level3（仅 GitHub Actions）骨架实现：此 Job 先验证事件链路与幂等，不直接改代码/开 PR。
-后续你确认接入模型与写入策略（开分支/开 PR/生成 evidence）后，再把这一段替换为真实执行步骤。
+已自动创建 PR 分支与 PR。由于你当前使用免费 Claude 账号（无法提供 `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` 给 Actions 自动改代码），接下来需要你在本地用 Cursor 来完成改动并推回该 PR 分支。
+
+本地执行步骤（建议复制到 Cursor Agent 执行）：
+1) checkout PR 分支：feat/issue-${ISSUE}-${MOD}
+2) 按 issue 需求改代码 + 补测试
+3) `cd backend && mvn test`
+4) 填写并提交：${evidence_dir}/summary.md（去掉 TODO）
+5) push 到远端分支
+6) 在 PR 上加标签：subagent:done（否则 `local-subagent-gate` 会阻止合并）
 EOF
 )" >/dev/null
 
@@ -149,6 +167,6 @@ EOF
           ISSUE: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          gh api -X POST "repos/${REPO}/issues/${ISSUE}/labels" -f labels[]="status:done" >/dev/null || true
-          gh api -X DELETE "repos/${REPO}/issues/${ISSUE}/labels/status:in_progress" >/dev/null || true
+          # Do not auto mark done here. Completion is driven by PR merge and/or manual subagent:done label gate.
+          echo "Skip auto status:done"
 

--- a/.github/workflows/local-subagent-gate.yml
+++ b/.github/workflows/local-subagent-gate.yml
@@ -1,0 +1,68 @@
+name: local-subagent-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  local-subagent-gate:
+    name: local-subagent-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce local subagent completion marker
+        env:
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # 1) Require PR label as manual acknowledgement that local Cursor agent finished.
+          has_label="$(gh api "repos/${REPO}/issues/${PR}" --jq '[.labels[].name] | any(. == "subagent:done")')"
+          if [ "${has_label}" != "true" ]; then
+            cat <<'EOF' >&2
+Missing required PR label: subagent:done
+
+How to satisfy:
+- Run the local Cursor agent on this PR branch to implement the issue + tests.
+- Update evidence summary.md (remove TODOs).
+- Add PR label: subagent:done
+EOF
+            exit 1
+          fi
+
+          # 2) Require evidence summaries to be filled (no TODO left).
+          # We only check files under backend/evidence/**/summary.md in this PR.
+          changed="$(git diff --name-only origin/main...HEAD | tr -d '\r' || true)"
+          if [ -z "${changed}" ]; then
+            echo "No changed files detected."
+          fi
+
+          summaries="$(echo "${changed}" | grep -E '^backend/evidence/.+/summary\.md$' || true)"
+          if [ -z "${summaries}" ]; then
+            echo "No evidence summary.md changed in this PR. (Allowed, but recommended.)"
+            exit 0
+          fi
+
+          bad=0
+          while IFS= read -r f; do
+            if rg -n "TODO" "$f" >/dev/null 2>&1; then
+              echo "Evidence file still contains TODO: $f" >&2
+              bad=1
+            fi
+          done <<< "${summaries}"
+
+          if [ "${bad}" -ne 0 ]; then
+            echo "Please fill evidence summary.md (remove TODO) before labeling subagent:done." >&2
+            exit 1
+          fi
+

--- a/SOP/AI-Delivery-SOP.md
+++ b/SOP/AI-Delivery-SOP.md
@@ -43,6 +43,7 @@
 - Require a pull request before merging
 - Require status checks to pass before merging
   - 必选：`backend-mvn-test`
+- 若你使用“本地 Cursor 作为子 agent”（免费 Claude 无法在 Actions 自动改代码），建议把 `local-subagent-gate` 也设为 Required，用来强制“本地已完成并自证”后才能合并
 - 个人仓库阶段建议：**Approvals = 0**（避免“作者不能 approve 自己 PR”导致无法合并）
 - 团队化后建议：对 HITL（`mode:HITL`）把 approvals 调回 >= 1，并按需把 `claude-code-review` 设为 Required
 


### PR DESCRIPTION
## Summary
- Add  check: requires PR label  and (if present) filled evidence  (no TODO).
- Update  to mention the new gate and guide using local Cursor to implement changes.
- Update ruleset template to require  along with .
- Update SOP with branch-protection guidance.

## Why
你的 Claude 免费账号无法在 GitHub Actions 内直接运行 Claude 自动改代码，因此用本地 Cursor 承担“子 agent 编码”。该 gate 让这一步变成**必须**，否则不能合并。

## Test plan
- Open any PR: observe  fails until label  is added.
- Add label : check turns green.


Made with [Cursor](https://cursor.com)