### PR TITLE
fix(compose): 后端纳入 compose + 前端登录链路修复

### DIFF
--- a/admin/nginx.conf
+++ b/admin/nginx.conf
@@ -1,0 +1,24 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA 路由：任意路径回落到 index.html
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # 同源代理后端 API，避免跨域
+  location /api/ {
+    # 后端已纳入 docker compose，同网段直连服务名更稳定
+    proxy_pass http://openinterview-backend:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+

--- a/admin/src/api/http.ts
+++ b/admin/src/api/http.ts
@@ -30,7 +30,8 @@ http.interceptors.response.use(
     if (!contentType.includes('application/json')) return resp
 
     const body = resp.data as Result<unknown>
-    if (body && typeof body.code === 'number' && body.code !== 0) {
+    // 后端约定：成功码为 200；历史/部分 mock 可能用 0
+    if (body && typeof body.code === 'number' && body.code !== 0 && body.code !== 200) {
       ElMessage.error(body.msg || '请求失败')
       return Promise.reject(new Error(body.msg || '业务错误'))
     }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,15 @@ WORKDIR /app
 COPY pom.xml ./
 COPY src ./src
 
-RUN --mount=type=cache,target=/root/.m2 mvn -B -DskipTests package
+# 关键点：
+# Spring Boot 打包后通常会出现两个 jar：
+# - 可执行 fat jar：xxx.jar（包含 Main-Class / Start-Class）
+# - 原始普通 jar：xxx-original.jar（不含可执行 manifest）
+# 不能用通配符随意拷贝，否则容易把 original.jar 当成启动 jar，导致 “no main manifest attribute”.
+RUN --mount=type=cache,target=/root/.m2 mvn -B -DskipTests package \
+  && JAR="$(ls -1 target/*.jar | grep -v -- '-original\\.jar$' | head -n 1)" \
+  && test -n "${JAR}" \
+  && cp "${JAR}" /app/app.jar
 
 FROM eclipse-temurin:17-jre
 WORKDIR /app
@@ -12,7 +20,7 @@ WORKDIR /app
 RUN useradd -r -u 10001 -g root appuser
 USER 10001
 
-COPY --from=build /app/target/*.jar /app/app.jar
+COPY --from=build /app/app.jar /app/app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -162,10 +162,19 @@
     </dependencies>
 
     <build>
+        <finalName>app</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
     username: ${RABBITMQ_USER:admin}
     password: ${RABBITMQ_PASS:123456}
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:3306/interview_platform?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8mb4}
+    url: ${DB_URL:jdbc:mysql://localhost:3306/interview_platform?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=UTF-8}
     username: ${DB_USER:root}
     password: ${DB_PASS:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,11 +65,17 @@ services:
       - openinterview
 
   backend:
-    build:
-      context: ./backend
+    # 说明：
+    # - 由于你当前环境拉取 docker.io 基础镜像会 403/EOF，backend 镜像无法稳定重建
+    # - 这里改成“宿主机 mvn 打包 + 容器运行”：
+    #   先执行：cd backend && mvn -DskipTests package
+    #   然后 compose 直接运行本地已有的 openinterview-backend:latest，并把 target/app.jar 挂载进去启动
+    image: openinterview-backend:latest
     container_name: openinterview-backend
+    volumes:
+      - ./backend/target/app.jar:/app/app.jar:ro
     environment:
-      DB_URL: jdbc:mysql://mysql:3306/interview_platform?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8mb4
+      DB_URL: jdbc:mysql://mysql:3306/interview_platform?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=UTF-8
       DB_USER: root
       DB_PASS: root
       REDIS_HOST: redis
@@ -109,10 +115,16 @@ services:
     networks:
       - openinterview
 
-  # TODO(#33): 用前端构建产物替换该占位服务（建议用 nginx 静态托管 dist/）
   frontend:
     image: nginx:alpine
     container_name: openinterview-frontend
+    volumes:
+      # 先在本机执行：cd admin && npm install && npm run build
+      - ./admin/dist:/usr/share/nginx/html:ro
+      - ./admin/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    extra_hosts:
+      # macOS/Windows 的 Docker Desktop 通常自带该域名；加这一行可增强兼容性（Linux 也可用 host-gateway）
+      - "host.docker.internal:host-gateway"
     ports:
       - "5173:80"
     networks:


### PR DESCRIPTION
## Summary
- 修复前端把后端 `code=200` 误判为失败导致的红色 ❌ 与不跳转问题（兼容 `0/200` 成功码）
- 修复后端 jar 打包（显式 repackage + 固定 `target/app.jar`），避免 `no main manifest attribute`
- docker compose 支持后端一起启动（宿主机 mvn 打包产物挂载到容器运行，规避镜像源 403/EOF 影响）
- 前端 Nginx `/api` 反代到 compose 内 `openinterview-backend:8080`

## Test plan
- [x] `POST http://localhost:5173/api/auth/login` 返回 200 且不再出现 502
- [x] `GET http://127.0.0.1:8080/actuator/health` 返回 UP

## Notes
- 当前环境 Docker Hub mirror 403/EOF，PR 里 compose backend 采用“宿主机构建 jar + 容器运行”的折中方案；待镜像拉取恢复后可再切回 `build: ./backend` 标准方式。

Made with [Cursor](https://cursor.com)